### PR TITLE
Fix face retraining 422 error by correcting ImageFolder dataset access

### DIFF
--- a/backend/app/threads/unlearn_face_FT_thread.py
+++ b/backend/app/threads/unlearn_face_FT_thread.py
@@ -91,7 +91,8 @@ class UnlearningFaceFTThread(threading.Thread):
         self.status.total_epochs = self.request.epochs
         
         dataset = self.train_set if UMAP_DATASET == 'train' else self.test_set
-        targets = torch.tensor(dataset.targets)
+        # For ImageFolder, targets are accessed via samples
+        targets = torch.tensor([sample[1] for sample in dataset.samples])
         class_indices = [(targets == i).nonzero().squeeze() for i in range(self.num_classes)]
         
         samples_per_class = UMAP_DATA_SIZE // self.num_classes
@@ -291,7 +292,8 @@ class UnlearningFaceFTThread(threading.Thread):
         detailed_results = []
         for i in range(len(umap_subset)):
             original_index = selected_indices[i]
-            ground_truth = umap_subset.dataset.targets[original_index]
+            # For ImageFolder, get ground truth from samples
+            ground_truth = umap_subset.dataset.samples[original_index][1]
             is_forget = (ground_truth == self.request.forget_class)
             detailed_results.append([
                 int(ground_truth),                             # gt

--- a/backend/app/threads/unlearn_face_GA_thread.py
+++ b/backend/app/threads/unlearn_face_GA_thread.py
@@ -92,7 +92,8 @@ class UnlearningFaceGAThread(threading.Thread):
         self.status.total_epochs = self.request.epochs
         
         dataset = self.train_set if UMAP_DATASET == 'train' else self.test_set
-        targets = torch.tensor(dataset.targets)
+        # For ImageFolder, targets are accessed via samples
+        targets = torch.tensor([sample[1] for sample in dataset.samples])
         class_indices = [(targets == i).nonzero().squeeze() for i in range(self.num_classes)]
         
         samples_per_class = UMAP_DATA_SIZE // self.num_classes
@@ -273,7 +274,8 @@ class UnlearningFaceGAThread(threading.Thread):
         detailed_results = []
         for i in range(len(umap_subset)):
             original_index = selected_indices[i]
-            ground_truth = umap_subset.dataset.targets[original_index]
+            # For ImageFolder, get ground truth from samples
+            ground_truth = umap_subset.dataset.samples[original_index][1]
             is_forget = (ground_truth == self.request.forget_class)
             detailed_results.append([
                 int(ground_truth),                             # gt

--- a/backend/app/threads/unlearn_face_RL_thread.py
+++ b/backend/app/threads/unlearn_face_RL_thread.py
@@ -105,7 +105,8 @@ class UnlearningFaceRLThread(threading.Thread):
         )
 
         dataset = self.train_set if UMAP_DATASET == 'train' else self.test_set
-        targets = torch.tensor(dataset.targets)
+        # For ImageFolder, targets are accessed via samples
+        targets = torch.tensor([sample[1] for sample in dataset.samples])
         class_indices = [(targets == i).nonzero().squeeze() for i in range(self.num_classes)]
         
         samples_per_class = UMAP_DATA_SIZE // self.num_classes
@@ -314,7 +315,8 @@ class UnlearningFaceRLThread(threading.Thread):
         detailed_results = []
         for i in range(len(umap_subset)):
             original_index = selected_indices[i]
-            ground_truth = umap_subset.dataset.targets[original_index]
+            # For ImageFolder, get ground truth from samples
+            ground_truth = umap_subset.dataset.samples[original_index][1]
             is_forget = (ground_truth == self.request.forget_class)
             detailed_results.append([
                 int(ground_truth),                             # gt

--- a/backend/app/threads/unlearn_face_custom_thread.py
+++ b/backend/app/threads/unlearn_face_custom_thread.py
@@ -88,7 +88,8 @@ class UnlearningFaceCustomThread(threading.Thread):
         
         dataset = self.train_set if UMAP_DATASET == 'train' else self.test_set
         
-        targets = torch.tensor(dataset.targets)
+        # For ImageFolder, targets are accessed via samples
+        targets = torch.tensor([sample[1] for sample in dataset.samples])
         class_indices = [(targets == i).nonzero().squeeze() for i in range(self.num_classes)]
         
         samples_per_class = UMAP_DATA_SIZE // self.num_classes
@@ -237,7 +238,8 @@ class UnlearningFaceCustomThread(threading.Thread):
         detailed_results = []
         for i in range(len(umap_subset)):
             original_index = selected_indices[i]
-            ground_truth = umap_subset.dataset.targets[original_index]
+            # For ImageFolder, get ground truth from samples
+            ground_truth = umap_subset.dataset.samples[original_index][1]
             is_forget = ground_truth == self.forget_class
             detailed_results.append([
                 int(ground_truth),                             # gt


### PR DESCRIPTION
- Replace dataset.targets with dataset.samples for ImageFolder datasets
- Fix ground truth access from samples instead of targets attribute
- Affects all face unlearning thread implementations (FT, GA, RL, custom)
- Resolves 422 Unprocessable Entity error during face retraining

🤖 Generated with [Claude Code](https://claude.ai/code)